### PR TITLE
Update stub classes to support Laravel Sail

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -10,6 +10,7 @@ This package will make [Laravel Dusk](https://github.com/laravel/dusk/) browser 
 * [Running both Firefox & Google Chrome](#running-firefox-and-chrome)
   * [Selecting desired browser in local environment](#selecting-browser-in-local)
   * [Selecting desired browser in continuous integration](#selecting-browser-in-ci)
+* [Running with Laravel Sail](#running-with-laravel-sail)
 * [Development](#development)
 * [FAQ](#faq)
 * [Contributing](#contributing)
@@ -156,6 +157,49 @@ This command will append environment variable `DUSK_CHROME=1` to your .env.dusk 
 #### Selecting desired browser in continuous integration
 
 When running automated test flows through tools such as Chipper CI, CircleCI, Travis CI, or Github Actions, you can setup one job to run Google Chrome and a second job for Firefox. The custom Artisan commands can be skipped and you can instead just set the environment variable. The job configured with `DUSK_CHROME=1` will run Google Chrome. The second job missing the environment variable defaults to Firefox.
+
+<a name="running-with-laravel-sail"></a>
+## Running with Laravel Sail
+
+Laravel Sail is a command-line interface for interacting with your Laravel application's Docker development environment. Laravel Dusk tests can run in Firefox once an additional Docker image is added to Sail's configuration file.
+
+Install this package using the `sail` commands:
+
+```
+./vendor/bin/sail composer require --dev derekmd/laravel-dusk-firefox
+./vendor/bin/sail artisan dusk:install-firefox
+```
+
+This will copy a `tests/DuskTestCase.php` file into your application that is configured to recognize Laravel Sail's environment variables.
+
+Now you must uncomment and edit the "selenium" service in the `docker-compose.yml` file to install [standalone Firefox for Selenium](https://github.com/SeleniumHQ/docker-selenium).
+
+```
+version: '3'
+services:
+    laravel.test:
+        # ....
+        depends_on:
+            - mysql
+            - redis
+            - selenium
+    selenium:
+        image: 'selenium/standalone-firefox'
+        volumes:
+            - '/dev/shm:/dev/shm'
+        networks:
+            - sail
+        depends_on:
+            - laravel.test
+```
+
+After saving your changes, run Laravel Dusk tests in Firefox by executing the command:
+
+```
+./vendor/bin/sail dusk
+```
+
+> This configuration only allows running Dusk test with Mozilla Firefox. To make the command `php artisan dusk:chrome` work with a "selenium/standalone-chrome" image, additional service and `sail.sh` file changes are required that fall outside the 80% use case of Laravel Sail.
 
 <a name="development"></a>
 ## Development

--- a/src/Firefox/SupportsFirefox.php
+++ b/src/Firefox/SupportsFirefox.php
@@ -113,4 +113,14 @@ trait SupportsFirefox
     {
         static::$firefoxDriver = $path;
     }
+
+    /**
+     * Determine if the tests are running within Laravel Sail.
+     *
+     * @return bool
+     */
+    protected static function runningFirefoxInSail()
+    {
+        return isset($_ENV['LARAVEL_SAIL']) && $_ENV['LARAVEL_SAIL'] == '1';
+    }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -21,6 +21,10 @@ abstract class DuskTestCase extends BaseTestCase
      */
     public static function prepare()
     {
+        if (static::runningFirefoxInSail()) {
+            return;
+        }
+
         if (env('DUSK_CHROME')) {
             static::startChromeDriver();
         } else {
@@ -56,7 +60,8 @@ abstract class DuskTestCase extends BaseTestCase
         ]);
 
         return RemoteWebDriver::create(
-            'http://localhost:9515', DesiredCapabilities::chrome()->setCapability(
+            $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
+            DesiredCapabilities::chrome()->setCapability(
                 ChromeOptions::CAPABILITY, $options
             )
         );
@@ -82,6 +87,9 @@ abstract class DuskTestCase extends BaseTestCase
         $capabilities->getCapability(FirefoxDriver::PROFILE)
             ->setPreference('devtools.console.stdout.content', true);
 
-        return RemoteWebDriver::create('http://localhost:4444', $capabilities);
+        return RemoteWebDriver::create(
+            $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:4444',
+            $capabilities
+        );
     }
 }

--- a/stubs/FirefoxDuskTestCase.stub
+++ b/stubs/FirefoxDuskTestCase.stub
@@ -20,6 +20,10 @@ abstract class DuskTestCase extends BaseTestCase
      */
     public static function prepare()
     {
+        if (static::runningFirefoxInSail()) {
+            return;
+        }
+
         static::startFirefoxDriver();
     }
 
@@ -43,6 +47,9 @@ abstract class DuskTestCase extends BaseTestCase
         $capabilities->getCapability(FirefoxDriver::PROFILE)
             ->setPreference('devtools.console.stdout.content', true);
 
-        return RemoteWebDriver::create('http://localhost:4444', $capabilities);
+        return RemoteWebDriver::create(
+            $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:4444',
+            $capabilities
+        );
     }
 }


### PR DESCRIPTION
The updates to support Laravel Sail are based on Taylor Otwell's changes to "laravel/dusk" stub classes: https://github.com/laravel/dusk/compare/c005c11576daef5b955b6650b37aa3f403391039...004df91c2d92d4d659c0327df85e96226d74b5bf

Users must edit Sail's `docker-compose.yml` file to configure the Docker image "selenium/standalone-firefox".

```
version: '3'
services:
    laravel.test:
        # ....
        depends_on:
            - mysql
            - redis
            - selenium
    selenium:
        image: 'selenium/standalone-firefox'
        volumes:
            - '/dev/shm:/dev/shm'
        networks:
            - sail
        depends_on:
            - laravel.test
```

Then these three commands will run Laravel Dusk in Firefox:

```
sail composer require --dev derekmd/laravel-dusk-firefox
sail artisan dusk:install-firefox
sail dusk
```

### Notes

* With Laravel Sail, JavaScript errors are not captured and written to a log file because the WebDriver proxy server process is no longer managed by the PHPUnit/Dusk script.
  * Laravel Dusk's Google Chrome implementation has the same issue.
* I'm currently unaware of a way to make the custom command `sail dusk:chrome` work without users manually (un)commenting `docker-compose.yml` selenium configurations to swap between Chrome & Firefox. Docker images "selenium/standalone-chrome" and "selenium/standalone-firefox" can't run simultaneously so you'll have to choose only one browser with Laravel Sail.