### PR TITLE
Add support for --browse argument

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,8 @@ After `tests/DuskTestCase.php` is copied into your application, you may update t
 ```php
 namespace Tests;
 
+use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
+use Derekmd\Dusk\Firefox\SupportsFirefox;
 use Facebook\WebDriver\Firefox\FirefoxDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
@@ -98,11 +100,11 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         $options = [
-            'args' => [
+            'args' => $this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
             ],
-        ];
+        ]);
 
         $capabilities = DesiredCapabilities::firefox()
             ->setCapability('moz:firefoxOptions', $options);
@@ -118,6 +120,7 @@ abstract class DuskTestCase extends BaseTestCase
 * Firefox profile boolean flag `devtools.console.stdout.content` must be turned on to generate logs for debugging JavaScript errors.
 * `--headless` runs tests without opening any windows which is useful for continuous integrations. Remove this option to see the browser viewport while the test runs.
 * `--window-size` controls the width and height of the browser viewport. If your UI assertions are failing from elements being off-screen, you may need to change this setting.
+* The `$this->filterHeadlessArguments()` call allows the `--headless` argument to be removed when the command `php artisan dusk --browse` is run during local dev. This allows the Firefox browser window to be displayed while Laravel Dusk tests run. Headless mode is still enabled when the command line argument `--browse` isn't used.
 
 Read the [Geckodriver usage documentation](https://firefox-source-docs.mozilla.org/testing/geckodriver/index.html) to see which options are available.
 

--- a/src/Concerns/TogglesHeadlessMode.php
+++ b/src/Concerns/TogglesHeadlessMode.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Derekmd\Dusk\Concerns;
+
+trait TogglesHeadlessMode
+{
+    /**
+     * Remove browser option arguments for headless mode when it is disabled.
+     *
+     * @param  array  $args
+     * @return array
+     */
+    protected function filterHeadlessArguments(array $args = [])
+    {
+        return collect($args)->when($this->hasHeadlessDisabled(), function ($args) {
+            return $args->diff([
+                '--disable-gpu',
+                '--headless',
+            ]);
+        })->values()->all();
+    }
+
+    /**
+     * Determine whether the Dusk command has disabled headless mode.
+     *
+     * @return bool
+     */
+    protected function hasHeadlessDisabled()
+    {
+        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
+               isset($_ENV['DUSK_HEADLESS_DISABLED']);
+    }
+}

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
 use Derekmd\Dusk\Firefox\SupportsFirefox;
 use Facebook\WebDriver\Chrome\ChromeOptions;
 use Facebook\WebDriver\Firefox\FirefoxDriver;
@@ -11,7 +12,7 @@ use Laravel\Dusk\TestCase as BaseTestCase;
 
 abstract class DuskTestCase extends BaseTestCase
 {
-    use CreatesApplication, SupportsFirefox;
+    use CreatesApplication, SupportsFirefox, TogglesHeadlessMode;
 
     /**
      * Prepare for Dusk test execution.
@@ -53,11 +54,11 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function chromeDriver()
     {
-        $options = (new ChromeOptions)->addArguments([
+        $options = (new ChromeOptions)->addArguments($this->filterHeadlessArguments([
             '--disable-gpu',
             '--headless',
             '--window-size=1920,1080',
-        ]);
+        ]));
 
         return RemoteWebDriver::create(
             $_ENV['DUSK_DRIVER_URL'] ?? 'http://localhost:9515',
@@ -75,10 +76,10 @@ abstract class DuskTestCase extends BaseTestCase
     protected function firefoxDriver()
     {
         $options = [
-            'args' => [
+            'args' => $this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
-            ],
+            ]),
         ];
 
         $capabilities = DesiredCapabilities::firefox()

--- a/stubs/FirefoxDuskTestCase.stub
+++ b/stubs/FirefoxDuskTestCase.stub
@@ -2,6 +2,7 @@
 
 namespace Tests;
 
+use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
 use Derekmd\Dusk\Firefox\SupportsFirefox;
 use Facebook\WebDriver\Firefox\FirefoxDriver;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
@@ -10,7 +11,7 @@ use Laravel\Dusk\TestCase as BaseTestCase;
 
 abstract class DuskTestCase extends BaseTestCase
 {
-    use CreatesApplication, SupportsFirefox;
+    use CreatesApplication, SupportsFirefox, TogglesHeadlessMode;
 
     /**
      * Prepare for Dusk test execution.
@@ -35,10 +36,10 @@ abstract class DuskTestCase extends BaseTestCase
     protected function driver()
     {
         $options = [
-            'args' => [
+            'args' => $this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
-            ],
+            ]),
         ];
 
         $capabilities = DesiredCapabilities::firefox()

--- a/tests/TogglesHeadlessModeTest.php
+++ b/tests/TogglesHeadlessModeTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace Derekmd\Dusk\Tests;
+
+use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+use Symfony\Component\Process\Process;
+
+class TogglesHeadlessModeTest extends TestCase
+{
+    use TogglesHeadlessMode;
+
+    protected function tearDown() : void
+    {
+        unset($_ENV['DUSK_HEADLESS_DISABLED']);
+
+        parent::tearDown();
+    }
+
+    public function test_building_arguments_with_headless_mode()
+    {
+        unset($_ENV['DUSK_HEADLESS_DISABLED']);
+
+        $args = $this->filterHeadlessArguments([
+            '--disable-gpu',
+            '--headless',
+            '--window-size=1920,1080',
+        ]);
+
+        $this->assertSame([
+            '--disable-gpu',
+            '--headless',
+            '--window-size=1920,1080',
+        ], $args);
+    }
+
+    public function test_building_arguments_when_headless_mode_is_disabled()
+    {
+        $_ENV['DUSK_HEADLESS_DISABLED'] = true;
+
+        $args = $this->filterHeadlessArguments([
+            '--disable-gpu',
+            '--headless',
+            '--window-size=1920,1080',
+        ]);
+
+        $this->assertSame(['--window-size=1920,1080'], $args);
+    }
+}


### PR DESCRIPTION
From: https://github.com/laravel/dusk/pull/870

Laravel Dusk v6.11.4 (likely to be tagged Feb 16, 2021) will add a `--browse` argument for local dev to disable headless mode. This will display the browser window as tests run.

This requires updating this package's stub files. Apps must re-run `php artisan dusk:install-firefox` or `php artisan dusk:install-firefox --with-chrome` to copy the new `tests/DuskTestCase.php` file into the app code base.