### PR TITLE
Fix Geckodriver download issues on Mac

### DIFF
--- a/src/OperatingSystem.php
+++ b/src/OperatingSystem.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Derekmd\Dusk;
+
+use Laravel\Dusk\OperatingSystem as BaseOperatingSystem;
+
+class OperatingSystem extends BaseOperatingSystem
+{
+    /**
+     * Get the identifier of the current operating system, exclusive of
+     * the architecture that OperatingSystem::id() returns.
+     *
+     * @return string
+     */
+    public static function parentId()
+    {
+        return static::onWindows() ? 'win' : (static::onMac() ? 'mac' : 'linux');
+    }
+}


### PR DESCRIPTION
The `dusk:firefox-driver` command is showing two issues on Mac:

1. Fix Geckodriver download using Laravel Dusk 6.12.0+

   Laravel packages outside "laravel/framework" have a looser interpretation of semvar. https://github.com/laravel/dusk/pull/876 changed the return values by public method `Laravel\Dusk\OperatingSystem::id()` when running in a Mac environment. It will now _sometimes_ include the architecture in the string. That caused this package's `dusk:firefox-driver` command to skip the `'mac'` operating system configuration.

    Remove the dependency on `OperatingSystem::id()` as Geckodriver doesn't (yet) have a distributed ARM binary.
2. Fix the command on Mac failing to capture the extracted filename from the downloaded .tar.gz file. PHP's `exec()` doesn't populate its `$output` array argument when run:
    * within a Laravel Artisan command
    * within the PHPUnit test suite
    `2>&1` seems to cause the `x geckodriver` output string to be captured in `$output` so there are some `stdout` pipe shenanigans afoot. Linux terminals and Mingw-w64 on Windows don't have this behavior.