### PR TITLE
Add MacOS & Windows test runs to CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -5,7 +5,7 @@ on:
   pull_request:
 
 jobs:
-  tests:
+  linux_tests:
     runs-on: ubuntu-latest
 
     strategy:
@@ -28,11 +28,73 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.0" --dev --no-update
+        composer require "phpunit/phpunit:^9.5" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
-      run: vendor/phpunit/phpunit/phpunit tests/DownloadBinaries.php
+      run: vendor/bin/phpunit tests/DownloadBinaries.php
 
     - name: Execute tests
-      run: vendor/phpunit/phpunit/phpunit --verbose
+      run: vendor/bin/phpunit --verbose
+  mac_tests:
+    runs-on: macos-latest
+
+    strategy:
+      matrix:
+        php: [8.0]
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: dom, curl, libxml, mbstring, zip
+        tools: composer:v2
+        coverage: none
+
+    - name: Install dependencies
+      run: |
+        composer require "phpunit/phpunit:^9.5" --dev --no-update
+        composer update --prefer-dist --no-interaction --no-progress --ansi
+
+    - name: Install Geckodriver
+      run: vendor/bin/phpunit tests/DownloadBinaries.php
+
+    - name: Execute tests
+      run: vendor/bin/phpunit --verbose
+  windows_tests:
+    runs-on: windows-latest
+
+    strategy:
+      matrix:
+        php: [8.0]
+
+    name: PHP ${{ matrix.php }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php }}
+        extensions: dom, curl, fileinfo, libxml, mbstring, zip
+        tools: composer:v2
+        coverage: none
+
+    - name: Install dependencies
+      run: |
+        composer require "phpunit/phpunit:^9.5" --dev --no-update
+        composer update --prefer-dist --no-interaction --no-progress --ansi
+
+    - name: Install Geckodriver
+      run: vendor/bin/phpunit tests/DownloadBinaries.php
+
+    - name: Execute tests
+      run: vendor/bin/phpunit --verbose

--- a/composer.json
+++ b/composer.json
@@ -26,9 +26,9 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.18",
-        "mockery/mockery": "^1.4.2",
-        "orchestra/testbench": "^6.12.0",
-        "phpunit/phpunit": "^9.3"
+        "mockery/mockery": "^1.4",
+        "orchestra/testbench": "^6.15",
+        "phpunit/phpunit": "^9.5"
     },
     "autoload": {
         "psr-4": {

--- a/src/Exceptions/DownloadException.php
+++ b/src/Exceptions/DownloadException.php
@@ -3,6 +3,7 @@
 namespace Derekmd\Dusk\Exceptions;
 
 use Exception;
+use GuzzleHttp\Exception\GuzzleException;
 
 class DownloadException extends Exception
 {
@@ -10,9 +11,9 @@ class DownloadException extends Exception
      * Create a download exception instance.
      *
      * @param  string  $url
-     * @param  \Exception|null  $previous
+     * @param  \GuzzleHttp\Exception\GuzzleException|null  $previous
      */
-    public function __construct($url, Exception $previous = null)
+    public function __construct($url, GuzzleException $previous = null)
     {
         parent::__construct(
             collect([
@@ -22,5 +23,17 @@ class DownloadException extends Exception
             $previous ? $previous->getCode() : 0,
             $previous
         );
+    }
+
+    /**
+     * Determine if the download failure reason is being HTTP rate limited.
+     * This may happen from CI environments with many clients on the same
+     * IP address fetching from GitHub.
+     *
+     * @return bool
+     */
+    public function isRateLimited()
+    {
+        return $this->getCode() === 403;
     }
 }


### PR DESCRIPTION
Ensure the `dusk:firefox-driver` tests are actually run on each operating system, although macOS Big Sur isn't available in the free tier.

The GitHub actions step "Install Geckodriver" to fetch 3 binaries may get rate limited so I'll have to watch the container results for the next bit.