### PR TITLE
Fix Firefox driver setup throwing an exception on every test

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "support": {
         "issues": "https://github.com/derekmd/laravel-dusk-firefox/issues",
-        "source": "https://github.com/spatie/laravel-query-builder"
+        "source": "https://github.com/derekmd/laravel-dusk-firefox"
     },
     "authors": [
         {
@@ -22,7 +22,8 @@
     "require": {
         "php": "^7.2|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "laravel/dusk": "^6.0"
+        "laravel/dusk": "^6.0",
+        "php-webdriver/webdriver": "^1.11.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",

--- a/readme.md
+++ b/readme.md
@@ -88,7 +88,7 @@ namespace Tests;
 
 use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
 use Derekmd\Dusk\Firefox\SupportsFirefox;
-use Facebook\WebDriver\Firefox\FirefoxDriver;
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
@@ -99,17 +99,13 @@ abstract class DuskTestCase extends BaseTestCase
 
     protected function driver()
     {
-        $options = [
-            'args' => $this->filterHeadlessArguments([
+        $capabilities = DesiredCapabilities::firefox();
+
+        $capabilities->getCapability(FirefoxOptions::CAPABILITY)
+            ->addArguments($this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
-            ],
-        ]);
-
-        $capabilities = DesiredCapabilities::firefox()
-            ->setCapability('moz:firefoxOptions', $options);
-
-        $capabilities->getCapability(FirefoxDriver::PROFILE)
+            ]))
             ->setPreference('devtools.console.stdout.content', true);
 
         return RemoteWebDriver::create('http://localhost:4444', $capabilities);

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -5,7 +5,7 @@ namespace Tests;
 use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
 use Derekmd\Dusk\Firefox\SupportsFirefox;
 use Facebook\WebDriver\Chrome\ChromeOptions;
-use Facebook\WebDriver\Firefox\FirefoxDriver;
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
@@ -75,17 +75,13 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function firefoxDriver()
     {
-        $options = [
-            'args' => $this->filterHeadlessArguments([
+        $capabilities = DesiredCapabilities::firefox();
+
+        $capabilities->getCapability(FirefoxOptions::CAPABILITY)
+            ->addArguments($this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
-            ]),
-        ];
-
-        $capabilities = DesiredCapabilities::firefox()
-            ->setCapability('moz:firefoxOptions', $options);
-
-        $capabilities->getCapability(FirefoxDriver::PROFILE)
+            ]))
             ->setPreference('devtools.console.stdout.content', true);
 
         return RemoteWebDriver::create(

--- a/stubs/FirefoxDuskTestCase.stub
+++ b/stubs/FirefoxDuskTestCase.stub
@@ -4,7 +4,7 @@ namespace Tests;
 
 use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
 use Derekmd\Dusk\Firefox\SupportsFirefox;
-use Facebook\WebDriver\Firefox\FirefoxDriver;
+use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
@@ -35,17 +35,13 @@ abstract class DuskTestCase extends BaseTestCase
      */
     protected function driver()
     {
-        $options = [
-            'args' => $this->filterHeadlessArguments([
+        $capabilities = DesiredCapabilities::firefox();
+
+        $capabilities->getCapability(FirefoxOptions::CAPABILITY)
+            ->addArguments($this->filterHeadlessArguments([
                 '--headless',
                 '--window-size=1920,1080',
-            ]),
-        ];
-
-        $capabilities = DesiredCapabilities::firefox()
-            ->setCapability('moz:firefoxOptions', $options);
-
-        $capabilities->getCapability(FirefoxDriver::PROFILE)
+            ]))
             ->setPreference('devtools.console.stdout.content', true);
 
         return RemoteWebDriver::create(


### PR DESCRIPTION
Fixes: https://github.com/derekmd/laravel-dusk-firefox/issues/14

Laravel Dusk dependency php-webdriver/webdriver made a breaking change on minor version v1.11.0 released May 3, 2021. It no longer configures a Firefox profile so this package's `DuskTestCase.php` stub files throw a null exception on statement:

```php
$capabilities->getCapability(FirefoxDriver::PROFILE)
    ->setPreference('devtools.console.stdout.content', true);
```

Laravel Dusk's composer.json is ^1.9.0, this will have to be bumped to ^1.11.0 since the stubs are updated to use the new PHP class `FirefoxOptions` unavailable in earlier versions.

Apps must re-run command `php artisan dusk:install-firefox {--with-chrome?}` to copy the updated stub to path `tests/DuskTestCase.php`.