### PR TITLE
Prepare test suite for laravel/framework 9.x

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -28,7 +28,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5" --dev --no-update
+        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
@@ -59,7 +59,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5" --dev --no-update
+        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
@@ -90,7 +90,7 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5" --dev --no-update
+        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver

--- a/composer.json
+++ b/composer.json
@@ -27,9 +27,9 @@
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "mockery/mockery": "^1.4",
-        "orchestra/testbench": "^6.15",
-        "phpunit/phpunit": "^9.5"
+        "mockery/mockery": "^1.4.4",
+        "orchestra/testbench": "^6.25|^7.0",
+        "phpunit/phpunit": "^9.5.10"
     },
     "autoload": {
         "psr-4": {

--- a/tests/Support/TempDirectory.php
+++ b/tests/Support/TempDirectory.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Derekmd\Dusk\Tests\Support;
+
+use League\Flysystem\Adapter\Local;
+use League\Flysystem\Filesystem;
+use League\Flysystem\Local\LocalFilesystemAdapter;
+
+class TempDirectory
+{
+    private $path;
+
+    /**
+     * Create a local temporary directory.
+     *
+     * @param  string  $path
+     */
+    public function __construct($path)
+    {
+        $this->path = $path;
+
+        $this->localFilesystem($path);
+    }
+
+    /**
+     * Get the path of the created local temporary directory.
+     *
+     * @param  string|null  $append
+     * @return string
+     */
+    public function path($append = null)
+    {
+        return $this->path.($append === null ? '' : '/'.$append);
+    }
+
+    /**
+     * Delete the created local temporary directory.
+     *
+     * @return void
+     */
+    public function delete()
+    {
+        $filesystem = $this->localFilesystem(dirname($this->path));
+
+        method_exists($filesystem, 'deleteDir')
+            ? $filesystem->deleteDir(basename($this->path))
+            : $filesystem->deleteDirectory(basename($this->path));
+    }
+
+    /**
+     * Open a local directory using league/flysystem version 1.x, 2.x, or 3.x.
+     *
+     * @param  string  $path
+     * @return \League\Flysystem\Filesystem
+     */
+    protected function localFilesystem($path)
+    {
+        $adapter = class_exists(Local::class)
+            ? new Local($path)
+            : new LocalFilesystemAdapter($path);
+
+        return new Filesystem($adapter);
+    }
+}


### PR DESCRIPTION
This package's `src/` directory and composer.json `"require"` dependencies don't require any changes for applications upgrading to Laravel 9.x.

However the test suite needs some updates for league/flysystem 3.x now used by Laravel 9.x. Add a new `TempDirectory` class supporting:

* Laravel 8.x dependency league/flysystem 1.x
  * `League\Flysystem\Adapter\Local`
  * `Filesystem::deleteDir()`
* Laravel 9.x dependency league/flysystem 3.x
  * `League\Flysystem\Local\LocalFilesystemAdapter`
  * `Filesystem::deleteDirectory()`

GitHub Actions running on PHP 8.0/8.1 install Laraval 9.x while the legacy PHP 7.3/7.4 Linux runs stick to Laravel 8.x.