### PR TITLE
Allow installing alongside laravel/dusk 7.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     "require": {
         "php": "^7.2|^8.0",
         "guzzlehttp/guzzle": "^6.0|^7.0",
-        "laravel/dusk": "^6.0",
+        "laravel/dusk": "^6.0|^7.0",
         "php-webdriver/webdriver": "^1.11.0"
     },
     "require-dev": {


### PR DESCRIPTION
Closes https://github.com/derekmd/laravel-dusk-firefox/issues/22

This package's `DuskTestCase.php`  doesn't contain any breaking changes but I'll still tag a new major version with "laravel/dusk" changing how Chromedriver binaries are handled. Apps that configured this package using `php artisan dusk:install-firefox --with-chrome` and wish to upgrade to "laravel/dusk" 7.x may need to starting calling `php artisan dusk:chrome-driver` in CI/CD since the Chromedriver binaries are no longer stored on Packagist.