### PR TITLE
[1.x] Support environment variable `DUSK_START_MAXIMIZED` for Chromedriver

### DIFF
--- a/src/Concerns/TogglesHeadlessMode.php
+++ b/src/Concerns/TogglesHeadlessMode.php
@@ -30,4 +30,15 @@ trait TogglesHeadlessMode
         return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
                isset($_ENV['DUSK_HEADLESS_DISABLED']);
     }
+
+    /**
+     * Determine if the browser window should start maximized.
+     *
+     * @return bool
+     */
+    protected function shouldStartMaximized()
+    {
+        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
+               isset($_ENV['DUSK_START_MAXIMIZED']);
+    }
 }

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -57,7 +57,7 @@ abstract class DuskTestCase extends BaseTestCase
         $options = (new ChromeOptions)->addArguments($this->filterHeadlessArguments([
             '--disable-gpu',
             '--headless',
-            '--window-size=1920,1080',
+            $this->shouldStartMaximized() ? '--start-maximized' : '--window-size=1920,1080',
         ]));
 
         return RemoteWebDriver::create(

--- a/stubs/FirefoxDuskTestCase.stub
+++ b/stubs/FirefoxDuskTestCase.stub
@@ -21,11 +21,9 @@ abstract class DuskTestCase extends BaseTestCase
      */
     public static function prepare()
     {
-        if (static::runningFirefoxInSail()) {
-            return;
+        if (! static::runningFirefoxInSail()) {
+            static::startFirefoxDriver();
         }
-
-        static::startFirefoxDriver();
     }
 
     /**


### PR DESCRIPTION
* https://github.com/laravel/dusk/pull/978

CI environments such as GitHub Actions can set `DUSK_START_MAXIMIZED=true` to open the web browser without needing to set an exact width x height.

* **This only works for Google Chrome** as `--start-maximized` is a capability option only supported by Chromedriver.
* Geckodriver will still [require calling](https://laravel.com/docs/dusk#resizing-browser-windows) `$browser->maximize()` within the test after the Mozilla Firefox browser window is created.

Apps must call `php artisan dusk:install-firefox --with-chrome` to copy the updated file stub with the new feature.