### PR TITLE
[1.x] Composer installation doesn't fetch `/tests` subdirectory

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+* text=auto
+/.github export-ignore
+/.php-cs-fixer export-ignore
+/phpunit.xml.dist export-ignore
+/tests export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore


### PR DESCRIPTION
When running `composer require --dev derekmd/laravel-dusk-firefox`, the `tests/` subdirectory shouldn't be downloaded when Composer option `--prefer-stable` is true. Add a .gitattributes file to exclude dev-only files in Laravel applications.