### PR TITLE
[1.x] Fix test suite failures from bad `ResponseInterface` mocks

### DIFF
--- a/src/Console/FirefoxDriverCommand.php
+++ b/src/Console/FirefoxDriverCommand.php
@@ -157,7 +157,7 @@ class FirefoxDriverCommand extends Command
     protected function latestVersion()
     {
         try {
-            $body = $this->downloadUrl($this->latestVersionUrl)->getBody();
+            $body = (string) $this->downloadUrl($this->latestVersionUrl)->getBody();
         } catch (DownloadException $e) {
             if (! $e->isRateLimited()) {
                 throw $e;

--- a/tests/FirefoxDriverCommandTest.php
+++ b/tests/FirefoxDriverCommandTest.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
 use GuzzleHttp\Psr7\Request;
 use GuzzleHttp\Psr7\Response;
+use GuzzleHttp\Psr7\Stream;
 use Mockery as m;
 use Orchestra\Testbench\TestCase;
 use Psr\Http\Message\ResponseInterface;
@@ -303,7 +304,12 @@ class FirefoxDriverCommandTest extends TestCase
 
         $response = m::mock(ResponseInterface::class);
         $response->shouldReceive('getBody')
-            ->andReturn($body);
+            ->andReturn(
+                m::mock(Stream::class, function ($mock) use ($body) {
+                    $mock->shouldReceive('__toString')
+                        ->andReturn($body);
+                })
+            );
 
         return $response;
     }


### PR DESCRIPTION
"psr/http-message":^2.0 added return type hints to methods: https://github.com/php-fig/http-message/commit/54df5d4d336354de566dc6bb5d99cc0954b117f8

The return type of `ResponseInterface::getBody()` should be a `Psr\Http\Message\StreamInterface` instance, not a raw `string`. Change the mock to return a `GuzzleHttp\Psr7\Stream` instance which implements `StreamInterface`.

The existing package code executes fine since method `FirefoxCommand::latestVersion()` calling `json_decode($body, true)` will invoke magic method `__toString()`. But tests now fail in CI with GitHub Actions setup bumping nested dependency "psr/http-message" to 2.5.0.