### PR TITLE
[3.x] Laravel Framework 11.x and Laravel Dusk 8.x support

### DIFF
--- a/.github/workflows/php-cs-fixer.yml
+++ b/.github/workflows/php-cs-fixer.yml
@@ -1,6 +1,18 @@
 name: Check PHP code style
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
+      - 1.x
+      - 2.x
+    paths-ignore:
+      - LICENSE.md
+      - readme.md
+  pull_request:
+    paths-ignore:
+      - LICENSE.md
+      - readme.md
 
 jobs:
     style:
@@ -8,9 +20,17 @@ jobs:
 
         steps:
             -   name: Checkout code
-                uses: actions/checkout@v2
+                uses: actions/checkout@v4
+
+            -   name: .php-cs-fixer.cache
+                uses: actions/cache@v4
+                with:
+                    path: .php-cs-fixer.cache
+                    key: ${{ runner.OS }}-${{ github.repository }}-php-cs-fixer-${{ github.sha }}
+                    restore-keys: |
+                        ${{ runner.OS }}-${{ github.repository }}-php-cs-fixer-
 
             -   name: Check style
                 uses: docker://oskarstark/php-cs-fixer-ga
                 with:
-                    args: --config=.php-cs-fixer.php --dry-run --diff
+                    args: --dry-run --diff

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,17 @@ name: tests
 
 on:
   push:
+    branches:
+      - master
+      - 1.x
+      - 2.x
+    paths-ignore:
+      - LICENSE.md
+      - readme.md
   pull_request:
+    paths-ignore:
+      - LICENSE.md
+      - readme.md
 
 jobs:
   linux_tests:
@@ -10,13 +20,16 @@ jobs:
 
     strategy:
       matrix:
-        php: [7.3, 7.4, 8.0, 8.1, 8.2]
+        php: [8.1, 8.2, 8.3]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} on Linux
+
+    env:
+      PHPUNIT_PACKAGE: ${{ matrix.php == '8.1' && 'phpunit/phpunit:^10.1' || 'phpunit/phpunit:^11.0' }}
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -28,26 +41,26 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
+        composer require "$PHPUNIT_PACKAGE" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
       run: vendor/bin/phpunit tests/DownloadBinaries.php
 
     - name: Execute tests
-      run: vendor/bin/phpunit --verbose
+      run: vendor/bin/phpunit
   mac_tests:
     runs-on: macos-latest
 
     strategy:
       matrix:
-        php: [8.1]
+        php: [8.3]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} on MacOS
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -59,26 +72,26 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
+        composer require "phpunit/phpunit:^11.0" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
       run: vendor/bin/phpunit tests/DownloadBinaries.php
 
     - name: Execute tests
-      run: vendor/bin/phpunit --verbose
+      run: vendor/bin/phpunit
   windows_tests:
     runs-on: windows-latest
 
     strategy:
       matrix:
-        php: [8.1]
+        php: [8.3]
 
-    name: PHP ${{ matrix.php }}
+    name: PHP ${{ matrix.php }} on MS Windows
 
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     - name: Setup PHP
       uses: shivammathur/setup-php@v2
@@ -90,11 +103,11 @@ jobs:
 
     - name: Install dependencies
       run: |
-        composer require "phpunit/phpunit:^9.5.10" --dev --no-update
+        composer require "phpunit/phpunit:^10.1" --dev --no-update
         composer update --prefer-dist --no-interaction --no-progress --ansi
 
     - name: Install Geckodriver
       run: vendor/bin/phpunit tests/DownloadBinaries.php
 
     - name: Execute tests
-      run: vendor/bin/phpunit --verbose
+      run: vendor/bin/phpunit

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 bin/geckodriver*
 storage
 vendor
-.php_cs.cache
+.php-cs-fixer.cache
 composer.lock
 coverage
 .phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ vendor
 .php-cs-fixer.cache
 composer.lock
 coverage
+.phpunit.cache
 .phpunit.result.cache
 phpunit.xml
 .idea

--- a/composer.json
+++ b/composer.json
@@ -20,16 +20,16 @@
         }
     ],
     "require": {
-        "php": "^7.2|^8.0",
-        "guzzlehttp/guzzle": "^6.0|^7.0",
-        "laravel/dusk": "^6.0|^7.0",
-        "php-webdriver/webdriver": "^1.11.0"
+        "php": "^8.1",
+        "guzzlehttp/guzzle": "^7.5",
+        "laravel/dusk": "^8.0",
+        "php-webdriver/webdriver": "^1.15.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.0",
-        "mockery/mockery": "^1.4.4",
-        "orchestra/testbench": "^6.25|^7.0",
-        "phpunit/phpunit": "^9.5.10"
+        "friendsofphp/php-cs-fixer": "^3.64",
+        "mockery/mockery": "^1.6.12",
+        "orchestra/testbench": "^8.19|^9.0",
+        "phpunit/phpunit": "^10.1|^11.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
     },
     "scripts": {
         "download": "vendor/bin/phpunit tests/DownloadBinaries.php",
+        "lint": "./vendor/bin/php-cs-fixer fix -vvv --dry-run --show-progress=dots --diff",
         "test": "vendor/bin/phpunit"
     },
     "extra": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,27 +1,23 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit backupGlobals="false"
-         backupStaticAttributes="false"
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         backupGlobals="false"
+         backupStaticProperties="false"
          beStrictAboutTestsThatDoNotTestAnything="false"
-         bootstrap="vendor/autoload.php"
+         cacheDirectory=".phpunit.cache"
          colors="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
-         failOnRisky="true"
-         failOnWarning="true"
          processIsolation="false"
          stopOnError="false"
          stopOnFailure="false"
-         verbose="true"
 >
     <testsuites>
         <testsuite name="Laravel Dusk for Firefox Test Suite">
             <directory suffix="Test.php">./tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+    <source>
+        <include>
+            <directory>src</directory>
+        </include>
+    </source>
 </phpunit>

--- a/readme.md
+++ b/readme.md
@@ -30,9 +30,10 @@ This package will make [Laravel Dusk](https://github.com/laravel/dusk/) browser 
 <a name="requirements"></a>
 ## Requirements
 
-* PHP 7.2+
-* Laravel Framework 6.0+
-* Laravel Dusk 6.0+
+* PHP 8.1+
+* Laravel Framework 10.0+
+* Laravel Dusk 8.0+
+* PHPUnit 10+
 * Latest version of Mozilla Firefox installed locally
 
 <a name="installation"></a>
@@ -285,6 +286,28 @@ or call PHPUnit directly:
    ```
    
    Xdebug may be awaiting a user interaction to continue from a code breakpoint. PHP extension Xdebug should be disabled in php.ini for running browser tests.
+7. Why is every test case failing with this error message?
+   
+   > Expected browser binary location, but unable to find binary in default locatio
+n, no 'moz:firefoxOptions.binary' capability provided, and no binary flag set on
+ the command line
+   
+   Mozilla Firefox v130.0.1 introduced a bug on MS Windows that configured the binary path using the incorrect registry keys. See https://github.com/mozilla/geckodriver/issues/2199 for more details. If a similar error happens again in the future, try one of the below options.
+   
+   1. Reinstall the latest Mozilla Firefox.
+   2. Add the Mozilla Firefox executable directory to your operating system's environment variable `$PATH`.
+   3. Update tests/DuskTestCase.php method `driver()` to define the absolute binary path:
+      
+      ```php
+      $capabilities = DesiredCapabilities::firefox();
+      
+      $capabilities->getCapability(FirefoxOptions::CAPABILITY)
+          // ...
+          ->setOption('binary', 'c:\Program Files (x86)\Mozilla Firefox\firefox.exe');
+      ```
+8. Does this package support Pest as a Laravel Dusk test runner?
+   
+   No, currently this only supports PHPUnit. Contributors can submit a pull request for Pest support that will need to update DuskTestCase.php stub installation and the `SupportsFirefox` trait.
 
 <a name="contributing"></a>
 ## Contributing

--- a/src/Concerns/TogglesHeadlessMode.php
+++ b/src/Concerns/TogglesHeadlessMode.php
@@ -19,26 +19,4 @@ trait TogglesHeadlessMode
             ]);
         })->values()->all();
     }
-
-    /**
-     * Determine whether the Dusk command has disabled headless mode.
-     *
-     * @return bool
-     */
-    protected function hasHeadlessDisabled()
-    {
-        return isset($_SERVER['DUSK_HEADLESS_DISABLED']) ||
-               isset($_ENV['DUSK_HEADLESS_DISABLED']);
-    }
-
-    /**
-     * Determine if the browser window should start maximized.
-     *
-     * @return bool
-     */
-    protected function shouldStartMaximized()
-    {
-        return isset($_SERVER['DUSK_START_MAXIMIZED']) ||
-               isset($_ENV['DUSK_START_MAXIMIZED']);
-    }
 }

--- a/src/Console/ChromeCommand.php
+++ b/src/Console/ChromeCommand.php
@@ -5,7 +5,9 @@ namespace Derekmd\Dusk\Console;
 use Derekmd\Dusk\DuskFile;
 use Illuminate\Console\Command;
 use Illuminate\Support\Str;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'dusk:chrome')]
 class ChromeCommand extends Command
 {
     /**

--- a/src/Console/FirefoxDriverCommand.php
+++ b/src/Console/FirefoxDriverCommand.php
@@ -7,11 +7,13 @@ use Derekmd\Dusk\Exceptions\DownloadException;
 use Derekmd\Dusk\OperatingSystem;
 use Illuminate\Console\Command;
 use RuntimeException;
+use Symfony\Component\Console\Attribute\AsCommand;
 
 /**
  * @copyright Proxy downloads are based on https://github.com/staudenmeir/dusk-updater
  *            by Jonas Staudenmeir.
  */
+#[AsCommand(name: 'dusk:firefox-driver')]
 class FirefoxDriverCommand extends Command
 {
     use DownloadsBinaries;

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -57,6 +57,15 @@ class InstallCommand extends Command
             return 1;
         }
 
+        // Laravel 11+ apps may not define a CreatesApplication trait.
+        if (! trait_exists(\Tests\CreatesApplication::class)) {
+            file_put_contents($stubDestination, str_replace(
+                'use CreatesApplication, ',
+                'use ',
+                file_get_contents($stubDestination),
+            ));
+        }
+
         $this->info('Firefox scaffolding installed successfully.');
 
         $this->comment('Downloading Geckodriver binaries...');

--- a/src/Console/InstallCommand.php
+++ b/src/Console/InstallCommand.php
@@ -3,7 +3,9 @@
 namespace Derekmd\Dusk\Console;
 
 use Illuminate\Console\Command;
+use Symfony\Component\Console\Attribute\AsCommand;
 
+#[AsCommand(name: 'dusk:install-firefox')]
 class InstallCommand extends Command
 {
     /**

--- a/src/Firefox/SupportsFirefox.php
+++ b/src/Firefox/SupportsFirefox.php
@@ -3,6 +3,7 @@
 namespace Derekmd\Dusk\Firefox;
 
 use Laravel\Dusk\Browser;
+use PHPUnit\Framework\Attributes\After;
 
 trait SupportsFirefox
 {
@@ -27,9 +28,7 @@ trait SupportsFirefox
      */
     protected static $firefoxLog;
 
-    /**
-     * @after
-     */
+    #[After]
     public function tearDownFirefoxConsoleOutput()
     {
         if (static::$firefoxLog) {

--- a/stubs/DuskTestCase.stub
+++ b/stubs/DuskTestCase.stub
@@ -9,6 +9,7 @@ use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -17,9 +18,9 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * Prepare for Dusk test execution.
      *
-     * @beforeClass
      * @return void
      */
+    #[BeforeClass]
     public static function prepare()
     {
         if (static::runningFirefoxInSail()) {

--- a/stubs/FirefoxDuskTestCase.stub
+++ b/stubs/FirefoxDuskTestCase.stub
@@ -8,6 +8,7 @@ use Facebook\WebDriver\Firefox\FirefoxOptions;
 use Facebook\WebDriver\Remote\DesiredCapabilities;
 use Facebook\WebDriver\Remote\RemoteWebDriver;
 use Laravel\Dusk\TestCase as BaseTestCase;
+use PHPUnit\Framework\Attributes\BeforeClass;
 
 abstract class DuskTestCase extends BaseTestCase
 {
@@ -16,9 +17,9 @@ abstract class DuskTestCase extends BaseTestCase
     /**
      * Prepare for Dusk test execution.
      *
-     * @beforeClass
      * @return void
      */
+    #[BeforeClass]
     public static function prepare()
     {
         if (! static::runningFirefoxInSail()) {

--- a/tests/Stubs/TogglesHeadlessModeStub.php
+++ b/tests/Stubs/TogglesHeadlessModeStub.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Derekmd\Dusk\Tests\Stubs;
+
+use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
+use Laravel\Dusk\TestCase;
+
+class TogglesHeadlessModeStub extends TestCase
+{
+    use TogglesHeadlessMode {
+        filterHeadlessArguments as filterHeadlessArgumentsProtected;
+    }
+
+    public function __construct()
+    {
+        parent::__construct('TogglesHeadless');
+    }
+
+    public function createApplication()
+    {
+        // Not needed in this test suite. Method must be declared for PHPUnit v10.
+    }
+
+    public function filterHeadlessArguments($args)
+    {
+        return $this->filterHeadlessArgumentsProtected($args);
+    }
+}

--- a/tests/TogglesHeadlessModeTest.php
+++ b/tests/TogglesHeadlessModeTest.php
@@ -2,14 +2,12 @@
 
 namespace Derekmd\Dusk\Tests;
 
-use Derekmd\Dusk\Concerns\TogglesHeadlessMode;
+use Derekmd\Dusk\Tests\Stubs\TogglesHeadlessModeStub;
 use PHPUnit\Framework\TestCase;
 
 class TogglesHeadlessModeTest extends TestCase
 {
-    use TogglesHeadlessMode;
-
-    protected function tearDown() : void
+    protected function tearDown(): void
     {
         unset($_ENV['DUSK_HEADLESS_DISABLED']);
 
@@ -20,7 +18,7 @@ class TogglesHeadlessModeTest extends TestCase
     {
         unset($_ENV['DUSK_HEADLESS_DISABLED']);
 
-        $args = $this->filterHeadlessArguments([
+        $args = (new TogglesHeadlessModeStub)->filterHeadlessArguments([
             '--disable-gpu',
             '--headless',
             '--window-size=1920,1080',
@@ -37,7 +35,7 @@ class TogglesHeadlessModeTest extends TestCase
     {
         $_ENV['DUSK_HEADLESS_DISABLED'] = true;
 
-        $args = $this->filterHeadlessArguments([
+        $args = (new TogglesHeadlessModeStub)->filterHeadlessArguments([
             '--disable-gpu',
             '--headless',
             '--window-size=1920,1080',


### PR DESCRIPTION
Fixes https://github.com/derekmd/laravel-dusk-firefox/issues/34

1. Major version bump Composer dependencies so 3.x of this package will support laravel/dusk:^8.0. This requires PHP v8.1+, Laravel Framework v10+, and PHPUnit v10+.
2. Replace deprecated PHPUnit annotations `@after` and `@beforeClass` with PHPUnit v10+ attributes `#[After]` and `#[BeforeClass]`.
3. Remove base test class stub methods `Derekmd\Dusk\Concerns\TogglesHeadlessMode::hasHeadlessDisabled()` and `shouldStartMaximized()` now redundant in Laravel Dusk v8.
   *  These are defined by Laravel Dusk's parent `TestCase` class: https://github.com/laravel/dusk/pull/1098
4. `Derekmd\Dusk\Console\*Command` classes now have lazy-definitions so these testing classes don't need to be instantiated when other Laravel commands are run in the local environment.
5. `php artisan dusk:install-firefox` handles apps missing trait tests/CreatesApplication.php. Laravel 11 has pulled this trait's code into the framework.

---

> [!NOTE]
> Apps upgrading to "derekmd/laravel-dusk-firefox" v3.0 may need to run command `php artisan dusk:install-firefox` or `php artisan dusk:install-firefox --with-chrome` to overwrite tests/DuskTestCase.php. If trait file tests/CreatesApplication.php still exists, this step isn't required.
